### PR TITLE
Pass through HTTP 429 to the nix daemon

### DIFF
--- a/magic-nix-cache/src/error.rs
+++ b/magic-nix-cache/src/error.rs
@@ -29,6 +29,10 @@ pub enum Error {
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let code = match &self {
+            Self::Api(gha_cache::api::Error::ApiError {
+                status: StatusCode::TOO_MANY_REQUESTS,
+                ..
+            }) => StatusCode::TOO_MANY_REQUESTS,
             // HACK: HTTP 418 makes Nix throw a visible error but not retry
             Self::Api(_) => StatusCode::IM_A_TEAPOT,
             Self::NotFound => StatusCode::NOT_FOUND,


### PR DESCRIPTION
Although the README / #17 documents that 429 is known to cause a substitution error, I've not found any reason why this error can't be passed through to the nix-daemon so it will attempt to retry the substitution after a delay rather than completely disabling the cache.

The nix daemon even has specific behavior for this case: https://github.com/NixOS/nix/blob/df9bd755a115ecdcdf6566c39167aad3d1b08da2/src/libstore/filetransfer.cc#L415