### PR TITLE
Refresh GitHub Actions JWT in the background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 name = "attic"
 version = "0.1.0"
-source = "git+https://github.com/DeterminateSystems/attic?branch=fixups-for-magic-nix-cache#aa0a6b9b59bc54070e0e97bfb84053f81fbef205"
+source = "git+https://github.com/DeterminateSystems/attic?branch=fixups-for-magic-nix-cache#536a0614711754ccfd3df050025b5aff612635ff"
 dependencies = [
  "async-stream",
  "base64",
@@ -262,7 +262,7 @@ dependencies = [
 [[package]]
 name = "attic-client"
 version = "0.1.0"
-source = "git+https://github.com/DeterminateSystems/attic?branch=fixups-for-magic-nix-cache#aa0a6b9b59bc54070e0e97bfb84053f81fbef205"
+source = "git+https://github.com/DeterminateSystems/attic?branch=fixups-for-magic-nix-cache#536a0614711754ccfd3df050025b5aff612635ff"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -293,7 +293,7 @@ dependencies = [
 [[package]]
 name = "attic-server"
 version = "0.1.0"
-source = "git+https://github.com/DeterminateSystems/attic?branch=fixups-for-magic-nix-cache#aa0a6b9b59bc54070e0e97bfb84053f81fbef205"
+source = "git+https://github.com/DeterminateSystems/attic?branch=fixups-for-magic-nix-cache#536a0614711754ccfd3df050025b5aff612635ff"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -344,7 +344,7 @@ dependencies = [
 [[package]]
 name = "attic-token"
 version = "0.1.0"
-source = "git+https://github.com/DeterminateSystems/attic?branch=fixups-for-magic-nix-cache#aa0a6b9b59bc54070e0e97bfb84053f81fbef205"
+source = "git+https://github.com/DeterminateSystems/attic?branch=fixups-for-magic-nix-cache#536a0614711754ccfd3df050025b5aff612635ff"
 dependencies = [
  "attic",
  "base64",


### PR DESCRIPTION
GitHub Actions JWTs are only valid for 5 minutes after being issued.

FlakeHub uses these JWTs for authentication, which means that after those 5 minutes have passed and the token is expired, FlakeHub (and by extension FlakeHub Cache) will no longer allow requests using this token.

However, GitHub gives us a way to repeatedly request new tokens, so we utilize that and refresh the token every 2 minutes (less than half of the lifetime of the token).