### PR TITLE
Don't run server in tokio::spawn

### DIFF
--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -26,7 +26,6 @@ use std::io::Write;
 use std::net::SocketAddr;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::exit;
 use std::sync::Arc;
 
 use ::attic::nix_store::NixStore;
@@ -417,7 +416,8 @@ async fn main_cli() -> Result<()> {
         .with_graceful_shutdown(async move {
             shutdown_receiver.await.ok();
             tracing::info!("Shutting down");
-        })?;
+        })
+        .await;
 
     // Notify diagnostics endpoint
     if let Some(diagnostic_endpoint) = diagnostic_endpoint {

--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -371,21 +371,6 @@ async fn main_cli() -> Result<()> {
 
     tracing::info!("Listening on {}", args.listen);
 
-    let server = axum::Server::bind(&args.listen)
-        .serve(app.into_make_service())
-        .with_graceful_shutdown(async move {
-            shutdown_receiver.await.ok();
-            tracing::info!("Shutting down");
-        });
-
-    // Spawn here so that post-startup tasks can proceed
-    tokio::spawn(async move {
-        if let Err(e) = server.await {
-            tracing::error!("failed to start up daemon: {e}");
-            exit(1);
-        }
-    });
-
     // Notify of startup via HTTP
     if let Some(startup_notification_url) = args.startup_notification_url {
         tracing::debug!("Startup notification via HTTP POST to {startup_notification_url}");
@@ -427,10 +412,19 @@ async fn main_cli() -> Result<()> {
         tracing::debug!("Created startup notification file at {startup_notification_file_path:?}");
     }
 
+    let ret = axum::Server::bind(&args.listen)
+        .serve(app.into_make_service())
+        .with_graceful_shutdown(async move {
+            shutdown_receiver.await.ok();
+            tracing::info!("Shutting down");
+        })?;
+
     // Notify diagnostics endpoint
     if let Some(diagnostic_endpoint) = diagnostic_endpoint {
         state.metrics.send(diagnostic_endpoint).await;
     }
+
+    ret?;
 
     Ok(())
 }


### PR DESCRIPTION
PR #65 seems to have created an issue where using `tokio::spawn` for the server process makes it unreachable via HTTP. Ad-hoc experiments in GitLab as well as triggering [this job](https://github.com/DeterminateSystems/magic-nix-cache-action/actions/runs/9037921845/job/25114843369) indicate that.
