### PR TITLE
Tie Nix package version to Cargo.toml version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
 
   outputs = { self, nixpkgs, nix, ... }@inputs:
     let
+      mncMeta = (builtins.fromTOML (builtins.readFile ./magic-nix-cache/Cargo.toml)).package;
       overlays = [ inputs.rust-overlay.overlays.default nix.overlays.default ];
       supportedSystems = [
         "aarch64-linux"
@@ -40,7 +41,9 @@
     in
     {
       packages = forEachSupportedSystem ({ pkgs, cranePkgs, ... }: rec {
-        magic-nix-cache = pkgs.callPackage ./package.nix { };
+        magic-nix-cache = pkgs.callPackage ./package.nix {
+          inherit (mncMeta) version;
+        };
         #inherit (cranePkgs) magic-nix-cache;
         default = magic-nix-cache;
       });

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,6 @@
 
   outputs = { self, nixpkgs, nix, ... }@inputs:
     let
-      mncMeta = (builtins.fromTOML (builtins.readFile ./magic-nix-cache/Cargo.toml)).package;
       overlays = [ inputs.rust-overlay.overlays.default nix.overlays.default ];
       supportedSystems = [
         "aarch64-linux"
@@ -41,9 +40,7 @@
     in
     {
       packages = forEachSupportedSystem ({ pkgs, cranePkgs, ... }: rec {
-        magic-nix-cache = pkgs.callPackage ./package.nix {
-          inherit (mncMeta) version;
-        };
+        magic-nix-cache = pkgs.callPackage ./package.nix { };
         #inherit (cranePkgs) magic-nix-cache;
         default = magic-nix-cache;
       });

--- a/package.nix
+++ b/package.nix
@@ -9,12 +9,11 @@
 , rust-analyzer
 , clippy
 , rustfmt
-, version
 }:
 
 let
   ignoredPaths = [ ".github" "target" "book" ];
-
+  version = (builtins.fromTOML (builtins.readFile ./magic-nix-cache/Cargo.toml)).package.version;
 in
 rustPlatform.buildRustPackage rec {
   pname = "magic-nix-cache";

--- a/package.nix
+++ b/package.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, rustPlatform
+{ lib
+, stdenv
+, rustPlatform
 , pkg-config
 , installShellFiles
 , nix
@@ -7,14 +9,16 @@
 , rust-analyzer
 , clippy
 , rustfmt
+, version
 }:
 
 let
   ignoredPaths = [ ".github" "target" "book" ];
 
-in rustPlatform.buildRustPackage rec {
+in
+rustPlatform.buildRustPackage rec {
   pname = "magic-nix-cache";
-  version = "0.1.0";
+  inherit version;
 
   src = lib.cleanSourceWith {
     filter = name: type: !(type == "directory" && builtins.elem (baseNameOf name) ignoredPaths);
@@ -30,7 +34,8 @@ in rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = [
-    nix boost
+    nix
+    boost
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     SystemConfiguration
   ]);


### PR DESCRIPTION
Right now, these are out of step. With these changes, the package version is drawn from the MNC's `Cargo.toml`.