### PR TITLE
netrc: fixup handling when using dnixd/uds

### DIFF
--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -219,9 +219,18 @@ async fn main_cli() -> Result<()> {
         let flakehub_cache_server = args
             .flakehub_cache_server
             .ok_or_else(|| anyhow!("--flakehub-cache-server is required"))?;
-        let flakehub_api_server_netrc = args
-            .flakehub_api_server_netrc
-            .ok_or_else(|| anyhow!("--flakehub-api-server-netrc is required"))?;
+
+        let flakehub_api_server_netrc = if dnixd_available {
+            let dnixd_netrc_path = PathBuf::from(DETERMINATE_STATE_DIR).join("netrc");
+            args.flakehub_api_server_netrc.unwrap_or(dnixd_netrc_path)
+        } else {
+            args.flakehub_api_server_netrc.ok_or_else(|| {
+                anyhow!(
+                    "--flakehub-api-server-netrc is required when determinate-nixd is unavailable"
+                )
+            })?
+        };
+
         let flakehub_flake_name = args.flakehub_flake_name;
 
         match flakehub::init_cache(

--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -233,6 +233,7 @@ async fn main_cli() -> Result<()> {
             &flakehub_cache_server,
             flakehub_flake_name,
             store.clone(),
+            dnixd_available,
         )
         .await
         {


### PR DESCRIPTION
1. Make `--flakehub-api-server-netrc` optional when dnixd-uds is available. Default it to the determinate netrc if unset.
2. Check that if dnixd-uds is available (aka used), that the netrc path is the determinate netrc path.
3. Don't try to upsert the cache entry in the netrc if using dnixd-uds.