### PR TITLE
cli: add defaults for flakehub endpoints, nix.conf path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,6 +2685,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uuid",
+ "xdg",
 ]
 
 [[package]]

--- a/magic-nix-cache/Cargo.toml
+++ b/magic-nix-cache/Cargo.toml
@@ -57,6 +57,7 @@ http = "1.0"
 http-body-util = "0.1"
 hyper = { version = "1.0.0", features = ["full"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
+xdg = { version = "2.5.2" }
 
 [dependencies.tokio]
 version = "1.28.0"


### PR DESCRIPTION
Before:

```
cargo run -- \
    --use-flakehub \
    --nix-conf ~/.config/nix/nix.conf \
	--flakehub-cache-server http://cache.flakehub.com \
    --flakehub-api-server-netrc /nix/var/determinate/netrc \
    --flakehub-api-server http://api.flakehub.com
```

After:

```
cargo run -- --use-flakehub
```