### PR TITLE
What if we used clap's defaults support?

### DIFF
--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -97,23 +97,23 @@ struct Args {
     diagnostic_endpoint: String,
 
     /// The FlakeHub API server.
-    #[arg(long)]
-    flakehub_api_server: Option<reqwest::Url>,
+    #[arg(long, default_value = "https://api.flakehub.com")]
+    flakehub_api_server: reqwest::Url,
 
     /// The path of the `netrc` file that contains the FlakeHub JWT token.
     #[arg(long)]
     flakehub_api_server_netrc: Option<PathBuf>,
 
     /// The FlakeHub binary cache server.
-    #[arg(long)]
-    flakehub_cache_server: Option<reqwest::Url>,
+    #[arg(long, default_value = "https://cache.flakehub.com")]
+    flakehub_cache_server: reqwest::Url,
 
     #[arg(long)]
     flakehub_flake_name: Option<String>,
 
     /// The location of `nix.conf`.
-    #[arg(long)]
-    nix_conf: Option<PathBuf>,
+    #[arg(long, default_value_os_t = default_nix_conf())]
+    nix_conf: PathBuf,
 
     /// Whether to use the GHA cache.
     #[arg(long)]
@@ -152,6 +152,15 @@ impl Args {
 
         Ok(())
     }
+}
+
+fn default_nix_conf() -> PathBuf {
+    xdg::BaseDirectories::new()
+        .with_context(|| "identifying XDG base directories")
+        .expect(
+            "Could not identify your home directory. Try setting the HOME environment variable.",
+        )
+        .get_config_file("nix/nix.conf")
 }
 
 /// The global server state.
@@ -199,13 +208,7 @@ async fn main_cli() -> Result<()> {
     let dnixd_uds_socket_path = dnixd_uds_socket_dir.join(DETERMINATE_NIXD_SOCKET_NAME);
     let dnixd_available = dnixd_uds_socket_path.exists();
 
-    let nix_conf_path: PathBuf = match args.nix_conf {
-        Some(nc) => nc,
-        None => {
-            let xdg = xdg::BaseDirectories::new().with_context(|| "failed to get xdg base dirs")?;
-            xdg.get_config_file("nix/nix.conf")
-        }
-    };
+    let nix_conf_path: PathBuf = args.nix_conf;
 
     // NOTE: we expect this to point to a user nix.conf
     // we always open/append to it to be able to append the extra-substituter for github-actions cache
@@ -224,10 +227,7 @@ async fn main_cli() -> Result<()> {
     let narinfo_negative_cache = Arc::new(RwLock::new(HashSet::new()));
 
     let flakehub_state = if args.use_flakehub {
-        let flakehub_cache_server = args.flakehub_cache_server.unwrap_or(
-            reqwest::Url::parse("https://cache.flakehub.com")
-                .expect("failed to parse default flakehub cache url"),
-        );
+        let flakehub_cache_server = args.flakehub_cache_server;
 
         let flakehub_api_server_netrc = if dnixd_available {
             let dnixd_netrc_path = PathBuf::from(DETERMINATE_STATE_DIR).join("netrc");
@@ -240,10 +240,7 @@ async fn main_cli() -> Result<()> {
             })?
         };
 
-        let flakehub_api_server = &args.flakehub_api_server.unwrap_or(
-            reqwest::Url::parse("https://api.flakehub.com")
-                .expect("failed to parse default flakehub api server"),
-        );
+        let flakehub_api_server = &args.flakehub_api_server;
 
         let flakehub_flake_name = args.flakehub_flake_name;
 


### PR DESCRIPTION
I think this might be a bit nicer, so the --help is useful:

```
      --flakehub-api-server <FLAKEHUB_API_SERVER>
          The FlakeHub API server
          
          [default: https://api.flakehub.com]

      --flakehub-cache-server <FLAKEHUB_CACHE_SERVER>
          The FlakeHub binary cache server
          
          [default: https://cache.flakehub.com]

      --nix-conf <NIX_CONF>
          The location of `nix.conf`
          
          [default: /Users/grahamchristensen/.config/nix/nix.conf]
```