### PR TITLE
Fix compatibility issues with alternative GHA cache implementation

### DIFF
--- a/gha-cache/src/api.rs
+++ b/gha-cache/src/api.rs
@@ -116,7 +116,7 @@ pub struct FileAllocation(CacheId);
 /// The ID of a cache.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(transparent)]
-struct CacheId(pub i32);
+struct CacheId(pub i64);
 
 /// An API error.
 #[derive(Debug, Clone)]
@@ -543,10 +543,13 @@ impl Api {
     }
 
     fn construct_url(&self, resource: &str) -> String {
-        format!(
-            "{}/_apis/artifactcache/{}",
-            self.credentials.cache_url, resource
-        )
+        let mut url = self.credentials.cache_url.clone();
+        if !url.ends_with('/') {
+            url.push('/');
+        }
+        url.push_str("_apis/artifactcache/");
+        url.push_str(resource);
+        url
     }
 }
 


### PR DESCRIPTION
Fixes two compatibility issues with the alternative GHA cache server implementation:

https://github.com/falcondev-oss/github-actions-cache-server

1. This implementation does not support redundant forward slashes in URL paths. The change allows magic-nix-cache to work properly regardless of whether ACTIONS_CACHE_URL ends in a forward slash or not.
2. The cache IDs returned by this implementation can be too big for an i32, so the representation of the CacheID type has been updated to an i64.