### PR TITLE
Bump GitHub action actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
             system: ARM64-macOS
             runner: macos-latest-xlarge
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Nix on ${{ matrix.systems.system }}
         uses: DeterminateSystems/nix-installer-action@main
       - name: Magic Nix Cache

--- a/.github/workflows/check-and-test.yaml
+++ b/.github/workflows/check-and-test.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -60,7 +60,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download closure for ${{ matrix.systems.system }}
         uses: actions/download-artifact@v3

--- a/.github/workflows/flakehub.yaml
+++ b/.github/workflows/flakehub.yaml
@@ -12,7 +12,7 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "DeterminateSystems/nix-installer-action@main"
       - uses: "DeterminateSystems/flakehub-push@main"
         with:

--- a/.github/workflows/keygen.yaml
+++ b/.github/workflows/keygen.yaml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write # In order to request a JWT for AWS auth
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create the artifacts directory
         run: rm -rf ./artifacts && mkdir ./artifacts

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write # In order to request a JWT for AWS auth
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create the artifacts directory
         run: rm -rf ./artifacts && mkdir ./artifacts

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ permissions:
   contents: read
   id-token: write
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: DeterminateSystems/nix-installer-action@main
   - uses: DeterminateSystems/magic-nix-cache-action@main
   - run: nix flake check
@@ -52,7 +52,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix flake check


### PR DESCRIPTION
The breaking change seems to be something about the default Node.js
runtime: https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400

Also in example in documentation, for the sake of the copy-pasting user
(me).
