### PR TITLE
Graham/fh 433 magic nix cache should disable GitHub actions cache when flakehub cache is enabled

### DIFF
--- a/.github/workflows/check-and-test.yaml
+++ b/.github/workflows/check-and-test.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
 
       - name: Test magic-nix-cache-action@main on ${{ matrix.systems.runner }}
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/magic-nix-cache-action@graham/fh-433-magic-nix-cache-should-disable-github-actions-cache-if
         with:
           source-binary: "${{ env.ARTIFACT_KEY }}/${{ env.ARCHIVE_NAME }}"
           _internal-strict-mode: true

--- a/magic-nix-cache/src/flakehub.rs
+++ b/magic-nix-cache/src/flakehub.rs
@@ -33,7 +33,7 @@ pub async fn init_cache(
     environment: Environment,
     flakehub_api_server: &Url,
     flakehub_cache_server: &Url,
-    flakehub_flake_name: Option<String>,
+    flakehub_flake_name: &Option<String>,
     store: Arc<NixStore>,
     auth_method: &super::FlakeHubAuthSource,
 ) -> Result<State> {

--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -367,7 +367,10 @@ async fn main_cli() -> Result<()> {
         None
     };
 
-    let gha_cache = if args.github_cache_preference() != CacheTrinary::Disabled {
+    let gha_cache = if (args.github_cache_preference() == CacheTrinary::Enabled)
+        || (args.github_cache_preference() == CacheTrinary::NoPreference
+            && flakehub_state.is_none())
+    {
         tracing::info!("Loading credentials from environment");
 
         let credentials = Credentials::load_from_env()

--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -313,7 +313,14 @@ async fn main_cli() -> Result<()> {
         }
 
         // When determinate-nixd is not available, but the user specified a netrc
-        (_, Some(path), Dnixd::Missing) => Some(FlakeHubAuthSource::Netrc(path.to_owned())),
+        (_, Some(path), Dnixd::Missing) => {
+            if path.exists() {
+                Some(FlakeHubAuthSource::Netrc(path.to_owned()))
+            } else {
+                tracing::debug!(path = %path.display(), "User-provided netrc does not exist");
+                None
+            }
+        }
 
         // User explicitly turned on flakehub cache, but we have no netrc and determinate-nixd is not present
         (CacheTrinary::Enabled, None, Dnixd::Missing) => {


### PR DESCRIPTION
Generally, the Github Actions cache is a less good experience than FlakeHub Cache. Using FHC + GHA makes for a less stellar experience. This PR makes it by default use only FHC if FHC is available, but allows a user to explicitly turn-on GHA in addition.