### PR TITLE
Add option for disabling closure computation in GHA cache

### DIFF
--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -127,6 +127,10 @@ struct Args {
     /// Whether or not to diff the store before and after Magic Nix Cache runs
     #[arg(long, default_value_t = false)]
     diff_store: bool,
+
+    /// (GHA only) Don't include the closure of the to-be-cached store paths
+    #[arg(long, default_value_t = false)]
+    no_closure: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
@@ -389,6 +393,7 @@ async fn main_cli() -> Result<()> {
             store.clone(),
             metrics.clone(),
             narinfo_negative_cache.clone(),
+            !args.no_closure,
         )
         .with_context(|| "Failed to initialize GitHub Actions Cache API")?;
 


### PR DESCRIPTION
Allows to only cache the built derivations without their closures.

This avoids polluting the GHA cache with many duplicate entries, which happens when a downstream derivation changes (and is rebuilt), but its dependencies don't (but would get pushed to the cache each time regardless).

Should reduce the impact of issues like #75.

Not sure how to test this properly, but verified manually that `OUT_PATHS=$(which bash) ./target/debug/magic-nix-cache --no-closure` enqueues only the bash NAR.