### PR TITLE
readme note about `runs.post`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ error: unable to download 'http://127.0.0.1:37515/<...>': HTTP error 418
 The caching daemon and Nix both handle this gracefully, and won't cause your CI to fail.
 When the rate limit is exceeded while pulling dependencies, your workflow may perform more builds than usual.
 When the rate limit is exceeded while uploading to the cache, the remainder of those store paths will be uploaded on the next run of the workflow.
+If the job fails or is canceled, any successfully built paths will be stored in the Magic Nix Cache (via [`runs.post`](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runspost)).
 
 ## Development
 


### PR DESCRIPTION
Does the Magic Nix Cache cache what has been successfully built if the job fails or is canceled?
I am guessing yes based on: `subscribe_uds_post_build_hook`
https://github.com/DeterminateSystems/magic-nix-cache/blob/296e9dc1af825f2c961c1caa61832609b1bf8a49/magic-nix-cache/src/pbh.rs#L21
Is that implemented with a `runs.post` hook? https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runspost

If true, can we add this detail to the readme?
Thank you