### PR TITLE
notify users about EOL of magic nix cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Magic Nix Cache
 
+> [!WARNING]
+> The [Magic Nix Cache will will stop working](https://determinate.systems/posts/magic-nix-cache-free-tier-eol) on **February 1st, 2025** unless you're on [GitHub Enterprise Server]([https://determinate.systems/posts/magic-nix-cache-free-tier-eol/](https://github.com/enterprise)).
+>
+> You can upgrade to [FlakeHub Cache](https://flakehub.com/cache) and get **one month free** using the coupon code **`FHC`**.
+>
+> For more information, read [this blog post](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/).
+
 Save 30-50%+ of CI time without any effort or cost.
 Use Magic Nix Cache, a totally free and zero-configuration binary cache for Nix on GitHub Actions.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Magic Nix Cache
 
 > [!WARNING]
-> The [Magic Nix Cache will will stop working](https://determinate.systems/posts/magic-nix-cache-free-tier-eol) on **February 1st, 2025** unless you're on [GitHub Enterprise Server]([https://determinate.systems/posts/magic-nix-cache-free-tier-eol/](https://github.com/enterprise)).
+> The [Magic Nix Cache will will stop working](https://determinate.systems/posts/magic-nix-cache-free-tier-eol) on **February 1st, 2025** unless you're on [GitHub Enterprise Server](https://github.com/enterprise).
 >
 > You can upgrade to [FlakeHub Cache](https://flakehub.com/cache) and get **one month free** using the coupon code **`FHC`**.
 >


### PR DESCRIPTION
closes https://github.com/DeterminateSystems/magic-nix-cache/issues/119

Just copy/pasted from the blog post: https://determinate.systems/posts/magic-nix-cache-free-tier-eol/