### PR TITLE
Port 0 handling, but less invasive

### DIFF
--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -552,7 +552,6 @@ async fn main_cli(args: Args, recorder: detsys_ids_client::Recorder) -> Result<(
         tracing::debug!("Created startup notification file at {startup_notification_file_path:?}");
     }
 
-    let listener = tokio::net::TcpListener::bind(&args.listen).await?;
     let ret = axum::serve(listener, app.into_make_service())
         .with_graceful_shutdown(async move {
             shutdown_token.cancelled_owned().await;

--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -484,11 +484,6 @@ async fn main_cli(args: Args, recorder: detsys_ids_client::Recorder) -> Result<(
 
     let app = app.layer(Extension(state.clone()));
 
-    let serve = axum::serve(listener, app.into_make_service()).with_graceful_shutdown(async move {
-        shutdown_token.cancelled_owned().await;
-        tracing::info!("Shutting down");
-    });
-
     let startup_blob = serde_json::json!({
         "address": listener_addr
     });
@@ -557,10 +552,17 @@ async fn main_cli(args: Args, recorder: detsys_ids_client::Recorder) -> Result<(
         tracing::debug!("Created startup notification file at {startup_notification_file_path:?}");
     }
 
+    let listener = tokio::net::TcpListener::bind(&args.listen).await?;
+    let ret = axum::serve(listener, app.into_make_service())
+        .with_graceful_shutdown(async move {
+            shutdown_token.cancelled_owned().await;
+            tracing::info!("Shutting down");
+        })
+        .await;
     // Notify diagnostics endpoint
     state.metrics.send().await;
 
-    serve.await?;
+    ret?;
 
     Ok(())
 }

--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -496,7 +496,7 @@ async fn main_cli(args: Args, recorder: detsys_ids_client::Recorder) -> Result<(
         let response = reqwest::Client::new()
             .post(startup_notification_url)
             .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .body(format!("{{\"address\": \"{addr}\"}}"))
+            .body(serde_json::json!({"address": listener_addr}).to_string())
             .send()
             .await;
         match response {


### PR DESCRIPTION
This change touches a lot less behavior by listening earlier. By listening earlier, we have the actual port number much sooner and don't need to adjust any of the other logic / flow.

Built on top of #169 but PR'd directly to main to make the diff more legible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup notifications and startup file now include a JSON payload with the actual bound listener address.
  * Configs and downstream startup hooks consistently use the discovered listener address instead of placeholders.

* **Chores**
  * CI workflow updated to use a forked action reference and to bind the action to a local listening port for startup signaling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->