### PR TITLE
Fix #172: Add cache listing and proper retry with shutdown awareness

### DIFF
--- a/gha-cache/src/api.rs
+++ b/gha-cache/src/api.rs
@@ -188,7 +188,7 @@ struct ListCachesResponse {
 #[derive(Debug, Deserialize)]
 struct CacheEntry {
     key: String,
-    // Other fields we don't need: id, ref, version, size_in_bytes, created_at, last_accessed_at
+    version: String,
 }
 
 /// A cache entry.
@@ -491,7 +491,7 @@ impl Api {
         let per_page = 100;
 
         loop {
-            // Use the version as a key prefix to only list caches for our version
+            // Fetch all caches; filter by version client-side after deserialization
             let url = format!(
                 "https://api.github.com/repos/{}/actions/caches?per_page={}&page={}",
                 github_repository, per_page, page
@@ -522,7 +522,9 @@ impl Api {
 
             let count = list_response.actions_caches.len();
             for cache in list_response.actions_caches {
-                all_keys.insert(cache.key);
+                if cache.version == self.version {
+                    all_keys.insert(cache.key);
+                }
             }
 
             if count < per_page {

--- a/gha-cache/src/api.rs
+++ b/gha-cache/src/api.rs
@@ -24,6 +24,7 @@ use reqwest::{
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::HashSet;
 use thiserror::Error;
 use tokio::{io::AsyncRead, sync::Semaphore};
 use twirp::client::Client as TwirpClient;
@@ -51,6 +52,11 @@ const CHUNK_SIZE: usize = 32 * 1024 * 1024;
 
 /// The number of chunks to upload at the same time.
 const MAX_CONCURRENCY: usize = 4;
+
+/// Configuration for retry behavior
+const MAX_RETRIES: u32 = 5;
+const BASE_RETRY_DELAY_MS: u64 = 1000;
+const MAX_RETRY_DELAY_MS: u64 = 60000;
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -81,6 +87,8 @@ pub enum Error {
     ApiError {
         status: StatusCode,
         info: ApiErrorInfo,
+        /// Retry-After header value in seconds, if present
+        retry_after: Option<u64>,
     },
 
     #[error("API error: 'not ok' response")]
@@ -94,6 +102,9 @@ pub enum Error {
 
     #[error("Too many collisions")]
     TooManyCollisions,
+
+    #[error("Shutting down, not retrying")]
+    ShuttingDown,
 }
 
 pub struct Api {
@@ -121,6 +132,9 @@ pub struct Api {
     circuit_breaker_429_tripped: Arc<AtomicBool>,
 
     circuit_breaker_429_tripped_callback: CircuitBreakerTrippedCallback,
+
+    /// Whether we're in shutdown mode (no retries, fail fast)
+    shutting_down: Arc<AtomicBool>,
 
     /// Backend request statistics.
     #[cfg(debug_assertions)]
@@ -162,6 +176,20 @@ pub enum ApiErrorInfo {
 pub struct StructuredApiError {
     /// A human-readable error message.
     message: String,
+}
+
+/// Response from the List Caches API
+#[derive(Debug, Deserialize)]
+struct ListCachesResponse {
+    total_count: u32,
+    actions_caches: Vec<CacheEntry>,
+}
+
+/// A cache entry from the List Caches API
+#[derive(Debug, Deserialize)]
+struct CacheEntry {
+    key: String,
+    // Other fields we don't need: id, ref, version, size_in_bytes, created_at, last_accessed_at
 }
 
 /// A cache entry.
@@ -325,6 +353,7 @@ impl Api {
             concurrency_limit: Arc::new(Semaphore::new(MAX_CONCURRENCY)),
             circuit_breaker_429_tripped: Arc::new(AtomicBool::from(false)),
             circuit_breaker_429_tripped_callback,
+            shutting_down: Arc::new(AtomicBool::new(false)),
             #[cfg(debug_assertions)]
             stats: Default::default(),
         })
@@ -334,10 +363,178 @@ impl Api {
         self.circuit_breaker_429_tripped.load(Ordering::Relaxed)
     }
 
+    /// Signal that we're shutting down - no more retries
+    pub fn signal_shutdown(&self) {
+        tracing::info!("API entering shutdown mode - no more retries");
+        self.shutting_down.store(true, Ordering::SeqCst);
+    }
+
+    /// Check if we're in shutdown mode
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutting_down.load(Ordering::SeqCst)
+    }
+
     /// Mutates the cache version/namespace.
     pub fn mutate_version(&mut self, data: &[u8]) {
         self.version_hasher.update(data);
         self.version = hex::encode(self.version_hasher.clone().finalize());
+    }
+
+    /// Execute a request with retry logic, respecting shutdown state
+    async fn execute_with_retry<F, Fut, T>(&self, operation_name: &str, f: F) -> Result<T>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        let mut attempt = 0;
+
+        loop {
+            match f().await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    // Check if it's a rate limit error
+                    if !is_rate_limit_error(&e) {
+                        // Not a rate limit error, don't retry
+                        return Err(e);
+                    }
+
+                    // If we're shutting down AND we got rate limited, stop immediately
+                    // This prevents hanging in CI when workflow-finish is called
+                    if self.is_shutting_down() {
+                        tracing::info!(
+                            "{}: shutting down and rate limited, stopping retries",
+                            operation_name
+                        );
+                        return Err(Error::ShuttingDown);
+                    }
+
+                    // Extract retry_after if available
+                    let retry_after = match &e {
+                        Error::ApiError { retry_after, .. } => *retry_after,
+                        _ => None,
+                    };
+
+                    attempt += 1;
+                    if attempt >= MAX_RETRIES {
+                        tracing::error!(
+                            "{}: max retries ({}) exceeded",
+                            operation_name,
+                            MAX_RETRIES
+                        );
+                        // Trip circuit breaker after max retries
+                        self.circuit_breaker_429_tripped
+                            .store(true, Ordering::Relaxed);
+                        (self.circuit_breaker_429_tripped_callback)();
+                        return Err(e);
+                    }
+
+                    // Calculate delay: use Retry-After if provided, otherwise exponential backoff
+                    let delay_ms = if let Some(secs) = retry_after {
+                        (secs * 1000).min(MAX_RETRY_DELAY_MS)
+                    } else {
+                        (BASE_RETRY_DELAY_MS * 2u64.pow(attempt - 1)).min(MAX_RETRY_DELAY_MS)
+                    };
+
+                    tracing::warn!(
+                        "{}: rate limited, attempt {}/{}, retrying in {}ms",
+                        operation_name,
+                        attempt,
+                        MAX_RETRIES,
+                        delay_ms
+                    );
+
+                    // Sleep with shutdown check - if shutdown happens during wait, abort
+                    let sleep_duration = std::time::Duration::from_millis(delay_ms);
+                    tokio::select! {
+                        _ = tokio::time::sleep(sleep_duration) => {
+                            // Sleep completed, retry the operation
+                        }
+                        _ = self.wait_for_shutdown() => {
+                            tracing::info!(
+                                "{}: shutdown signaled during retry wait, aborting",
+                                operation_name
+                            );
+                            return Err(Error::ShuttingDown);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Wait until shutdown is signaled
+    async fn wait_for_shutdown(&self) {
+        loop {
+            if self.is_shutting_down() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
+
+    /// Lists all existing cache keys for this repository.
+    /// Returns a HashSet of cache keys that can be used to skip redundant uploads.
+    pub async fn list_existing_cache_keys(&self) -> Result<HashSet<String>> {
+        let (github_token, github_repository) = match (
+            &self.credentials.github_token,
+            &self.credentials.github_repository,
+        ) {
+            (Some(token), Some(repo)) => (token, repo),
+            _ => {
+                tracing::debug!(
+                    "GITHUB_TOKEN or GITHUB_REPOSITORY not set, skipping cache listing"
+                );
+                return Ok(HashSet::new());
+            }
+        };
+
+        let mut all_keys = HashSet::new();
+        let mut page = 1;
+        let per_page = 100;
+
+        loop {
+            // Use the version as a key prefix to only list caches for our version
+            let url = format!(
+                "https://api.github.com/repos/{}/actions/caches?per_page={}&page={}",
+                github_repository, per_page, page
+            );
+
+            #[cfg(debug_assertions)]
+            self.stats.get.fetch_add(1, Ordering::SeqCst);
+
+            let response = self
+                .client
+                .get(&url)
+                .header("Authorization", format!("Bearer {}", github_token))
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .header("Accept", "application/vnd.github+json")
+                .send()
+                .await?;
+
+            let status = response.status();
+            if !status.is_success() {
+                tracing::warn!(
+                    "Failed to list caches (status {}), continuing without cache listing",
+                    status
+                );
+                return Ok(all_keys);
+            }
+
+            let list_response: ListCachesResponse = response.json().await?;
+
+            let count = list_response.actions_caches.len();
+            for cache in list_response.actions_caches {
+                all_keys.insert(cache.key);
+            }
+
+            if count < per_page {
+                break; // Last page
+            }
+            page += 1;
+        }
+
+        tracing::info!("Found {} existing cache entries", all_keys.len());
+        Ok(all_keys)
     }
 
     // Public
@@ -483,19 +680,16 @@ impl Api {
                 #[cfg(debug_assertions)]
                 self.stats.post.fetch_add(1, Ordering::SeqCst);
 
-                if let Err(e) = self
-                    .client
-                    .post(self.construct_url(&format!("caches/{}", cache_id.0)))
-                    .json(&req)
-                    .send()
-                    .await?
-                    .check()
-                    .await
-                {
-                    self.circuit_breaker_429_tripped
-                        .check_err(&e, &self.circuit_breaker_429_tripped_callback);
-                    return Err(e);
-                }
+                self.execute_with_retry("commit_cache", || async {
+                    self.client
+                        .post(self.construct_url(&format!("caches/{}", cache_id.0)))
+                        .json(&req)
+                        .send()
+                        .await?
+                        .check()
+                        .await
+                })
+                .await?;
 
                 Ok(offset)
             }
@@ -578,26 +772,25 @@ impl Api {
 
                 let request = FinalizeCacheEntryUploadRequest {
                     metadata: None,
-                    key,
+                    key: key.clone(),
                     size_bytes: offset as i64,
                     version: self.version.clone(),
                 };
 
-                self.twirp_client
-                    .finalize_cache_entry_upload(request)
-                    .await
-                    .map_err(|e| e.into())
-                    .and_then(|response| {
-                        if response.ok {
-                            Ok(offset)
-                        } else {
-                            Err(Error::ApiErrorNotOk)
-                        }
-                    })
-                    .inspect_err(|e| {
-                        self.circuit_breaker_429_tripped
-                            .check_err(&e, &self.circuit_breaker_429_tripped_callback);
-                    })
+                self.execute_with_retry("finalize_cache", || async {
+                    self.twirp_client
+                        .finalize_cache_entry_upload(request.clone())
+                        .await
+                        .map_err(|e| e.into())
+                        .and_then(|response| {
+                            if response.ok {
+                                Ok(offset)
+                            } else {
+                                Err(Error::ApiErrorNotOk)
+                            }
+                        })
+                })
+                .await
             }
         }
     }
@@ -627,50 +820,52 @@ impl Api {
             return Err(Error::CircuitBreakerTripped);
         }
 
+        let keys_vec: Vec<String> = keys.iter().map(|k| k.to_string()).collect();
+        let version = self.version.clone();
+
         #[cfg(debug_assertions)]
         self.stats.get.fetch_add(1, Ordering::SeqCst);
 
         if self.credentials.service_v2.is_empty() {
-            let res = self
-                .client
-                .get(self.construct_url("cache"))
-                .query(&[("version", &self.version), ("keys", &keys.join(","))])
-                .send()
-                .await?
-                .check_json::<ArtifactCacheEntry>()
-                .await;
+            self.execute_with_retry("get_cache_entry", || async {
+                let res = self
+                    .client
+                    .get(self.construct_url("cache"))
+                    .query(&[("version", &version), ("keys", &keys_vec.join(","))])
+                    .send()
+                    .await?
+                    .check_json::<ArtifactCacheEntry>()
+                    .await;
 
-            self.circuit_breaker_429_tripped
-                .check_result(&res, &self.circuit_breaker_429_tripped_callback);
-
-            match res {
-                Ok(entry) => Ok(Some(entry.archive_location)),
-                Err(Error::DecodeError { status, .. }) if status == StatusCode::NO_CONTENT => {
-                    Ok(None)
-                }
-                Err(e) => Err(e),
-            }
-        } else {
-            self.twirp_client
-                .get_cache_entry_download_url(GetCacheEntryDownloadUrlRequest {
-                    version: self.version.clone(),
-                    key: keys[0].to_string(),
-                    restore_keys: keys.iter().map(|k| k.to_string()).collect(),
-                    metadata: None,
-                })
-                .await
-                .map_err(|e| e.into())
-                .and_then(|entry| {
-                    if entry.ok {
-                        Ok(Some(entry.signed_download_url))
-                    } else {
+                match res {
+                    Ok(entry) => Ok(Some(entry.archive_location)),
+                    Err(Error::DecodeError { status, .. }) if status == StatusCode::NO_CONTENT => {
                         Ok(None)
                     }
-                })
-                .inspect_err(|e| {
-                    self.circuit_breaker_429_tripped
-                        .check_err(&e, &self.circuit_breaker_429_tripped_callback);
-                })
+                    Err(e) => Err(e),
+                }
+            })
+            .await
+        } else {
+            self.execute_with_retry("get_cache_entry", || async {
+                self.twirp_client
+                    .get_cache_entry_download_url(GetCacheEntryDownloadUrlRequest {
+                        version: version.clone(),
+                        key: keys_vec[0].clone(),
+                        restore_keys: keys_vec.clone(),
+                        metadata: None,
+                    })
+                    .await
+                    .map_err(|e| e.into())
+                    .and_then(|entry| {
+                        if entry.ok {
+                            Ok(Some(entry.signed_download_url))
+                        } else {
+                            Ok(None)
+                        }
+                    })
+            })
+            .await
         }
     }
 
@@ -684,57 +879,59 @@ impl Api {
             return Err(Error::CircuitBreakerTripped);
         }
 
+        let key = key.to_string();
+        let version = self.version.clone();
+
         if self.credentials.service_v2.is_empty() {
-            let req = ReserveCacheRequest {
-                key,
-                version: &self.version,
-                cache_size,
-            };
+            self.execute_with_retry("reserve_cache", || async {
+                let req = ReserveCacheRequest {
+                    key: &key,
+                    version: &version,
+                    cache_size,
+                };
 
-            #[cfg(debug_assertions)]
-            self.stats.post.fetch_add(1, Ordering::SeqCst);
+                #[cfg(debug_assertions)]
+                self.stats.post.fetch_add(1, Ordering::SeqCst);
 
-            let res = self
-                .client
-                .post(self.construct_url("caches"))
-                .json(&req)
-                .send()
-                .await?
-                .check_json::<ReserveCacheResponse>()
-                .await;
+                let res = self
+                    .client
+                    .post(self.construct_url("caches"))
+                    .json(&req)
+                    .send()
+                    .await?
+                    .check_json::<ReserveCacheResponse>()
+                    .await?;
 
-            self.circuit_breaker_429_tripped
-                .check_result(&res, &self.circuit_breaker_429_tripped_callback);
-
-            Ok(FileAllocation::V1(res?.cache_id))
+                Ok(FileAllocation::V1(res.cache_id))
+            })
+            .await
         } else {
-            let req = CreateCacheEntryRequest {
-                metadata: None,
-                key: key.to_string(),
-                version: self.version.clone(),
-            };
+            self.execute_with_retry("reserve_cache", || async {
+                let req = CreateCacheEntryRequest {
+                    metadata: None,
+                    key: key.clone(),
+                    version: version.clone(),
+                };
 
-            let res = self
-                .twirp_client
-                .create_cache_entry(req)
-                .await
-                .map_err(|e| e.into())
-                .and_then(|response| {
-                    if response.ok {
-                        Ok(response)
-                    } else {
-                        Err(Error::ApiErrorNotOk)
-                    }
-                })
-                .inspect_err(|e| {
-                    self.circuit_breaker_429_tripped
-                        .check_err(&e, &self.circuit_breaker_429_tripped_callback);
-                })?;
+                let res = self
+                    .twirp_client
+                    .create_cache_entry(req)
+                    .await
+                    .map_err(|e| e.into())
+                    .and_then(|response| {
+                        if response.ok {
+                            Ok(response)
+                        } else {
+                            Err(Error::ApiErrorNotOk)
+                        }
+                    })?;
 
-            Ok(FileAllocation::V2(SignedUrl {
-                signed_url: res.signed_upload_url,
-                key: key.to_string(),
-            }))
+                Ok(FileAllocation::V2(SignedUrl {
+                    signed_url: res.signed_upload_url,
+                    key: key.clone(),
+                }))
+            })
+            .await
         }
     }
 
@@ -784,6 +981,14 @@ impl ResponseExt for reqwest::Response {
 
 async fn handle_error(res: reqwest::Response) -> Error {
     let status = res.status();
+
+    // Parse Retry-After header
+    let retry_after = res
+        .headers()
+        .get("Retry-After")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok());
+
     let bytes = match res.bytes().await {
         Ok(bytes) => {
             let bom = Bom::from(bytes.as_ref());
@@ -802,7 +1007,30 @@ async fn handle_error(res: reqwest::Response) -> Error {
         }
     };
 
-    Error::ApiError { status, info }
+    Error::ApiError {
+        status,
+        info,
+        retry_after,
+    }
+}
+
+/// Check if an error is a rate limit error that should trigger retry/circuit breaker
+fn is_rate_limit_error(e: &Error) -> bool {
+    matches!(
+        e,
+        Error::ApiError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            ..
+        } | Error::TwirpError(ClientError::TwirpError(TwirpErrorResponse {
+            code: TwirpErrorCode::ResourceExhausted,
+            ..
+        })) | Error::TwirpError(ClientError::HttpError {
+            // The cache backend seems to give out this error for overload:
+            // Twirp error: http error, status code: 502 Bad Gateway, msg:unknown error
+            status: StatusCode::BAD_GATEWAY,
+            ..
+        })
+    )
 }
 
 trait AtomicCircuitBreaker {
@@ -826,27 +1054,9 @@ impl AtomicCircuitBreaker for AtomicBool {
     }
 
     fn check_err(&self, e: &Error, callback: &CircuitBreakerTrippedCallback) {
-        match e {
-            Error::ApiError {
-                status: reqwest::StatusCode::TOO_MANY_REQUESTS,
-                ..
-            }
-            | Error::TwirpError(ClientError::TwirpError(TwirpErrorResponse {
-                code: TwirpErrorCode::ResourceExhausted,
-                ..
-            }))
-            | Error::TwirpError(ClientError::HttpError {
-                // The cache backend seems to give out this error for overload:
-                // Twirp error: http error, status code: 502 Bad Gateway, msg:unknown error
-                status: StatusCode::BAD_GATEWAY,
-                ..
-            }) => {
-                // meat is below
-            }
-            otherwise => {
-                tracing::error!(%otherwise, "Checked error for resource exhaustion, but it appears to be a different cause");
-                return;
-            }
+        if !is_rate_limit_error(e) {
+            tracing::error!(%e, "Checked error for resource exhaustion, but it appears to be a different cause");
+            return;
         }
 
         tracing::info!(%e, "Disabling GitHub Actions Cache due to rate limiting");

--- a/gha-cache/src/credentials.rs
+++ b/gha-cache/src/credentials.rs
@@ -33,6 +33,19 @@ pub struct Credentials {
     /// This is the `ACTIONS_CACHE_SERVICE_V2` environment variable.
     #[serde(alias = "ACTIONS_CACHE_SERVICE_V2")]
     pub(crate) service_v2: String,
+
+    /// GitHub token for REST API calls (listing caches).
+    ///
+    /// This is the `GITHUB_TOKEN` environment variable.
+    #[derivative(Debug = "ignore")]
+    #[serde(alias = "GITHUB_TOKEN")]
+    pub(crate) github_token: Option<String>,
+
+    /// Repository in "owner/repo" format.
+    ///
+    /// This is the `GITHUB_REPOSITORY` environment variable.
+    #[serde(alias = "GITHUB_REPOSITORY")]
+    pub(crate) github_repository: Option<String>,
 }
 
 impl Credentials {
@@ -43,11 +56,17 @@ impl Credentials {
         let runtime_token = env::var("ACTIONS_RUNTIME_TOKEN").ok()?;
         let service_v2 = env::var("ACTIONS_CACHE_SERVICE_V2").ok()?;
 
+        // Optional - for listing caches via REST API
+        let github_token = env::var("GITHUB_TOKEN").ok();
+        let github_repository = env::var("GITHUB_REPOSITORY").ok();
+
         Some(Self {
             cache_url,
             results_url,
             runtime_token,
             service_v2,
+            github_token,
+            github_repository,
         })
     }
 }

--- a/magic-nix-cache/src/gha.rs
+++ b/magic-nix-cache/src/gha.rs
@@ -21,6 +21,9 @@ pub struct GhaCache {
     worker_result: RwLock<Option<tokio::task::JoinHandle<Result<()>>>>,
 
     channel_tx: UnboundedSender<Request>,
+
+    /// Cache keys that already exist (fetched on startup, updated on upload)
+    existing_keys: Arc<RwLock<HashSet<String>>>,
 }
 
 #[derive(Debug)]
@@ -30,7 +33,7 @@ enum Request {
 }
 
 impl GhaCache {
-    pub fn new(
+    pub async fn new(
         credentials: Credentials,
         cache_version: Option<String>,
         store: Arc<NixStore>,
@@ -55,7 +58,20 @@ impl GhaCache {
 
         let api = Arc::new(api);
 
+        // Fetch existing cache keys (best effort - don't fail if this doesn't work)
+        let existing_keys = Arc::new(RwLock::new(match api.list_existing_cache_keys().await {
+            Ok(keys) => keys,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to list existing caches: {}. Uploads may be redundant.",
+                    e
+                );
+                HashSet::new()
+            }
+        }));
+
         let api2 = api.clone();
+        let existing_keys2 = existing_keys.clone();
 
         let worker_result = tokio::task::spawn(async move {
             worker(
@@ -64,6 +80,7 @@ impl GhaCache {
                 channel_rx,
                 metrics,
                 narinfo_negative_cache.clone(),
+                existing_keys2,
             )
             .await
         });
@@ -72,10 +89,14 @@ impl GhaCache {
             api,
             worker_result: RwLock::new(Some(worker_result)),
             channel_tx,
+            existing_keys,
         })
     }
 
     pub async fn shutdown(&self) -> Result<()> {
+        // Signal API to stop retrying
+        self.api.signal_shutdown();
+
         if let Some(worker_result) = self.worker_result.write().await.take() {
             self.channel_tx
                 .send(Request::Shutdown)
@@ -120,17 +141,36 @@ async fn worker(
     mut channel_rx: UnboundedReceiver<Request>,
     metrics: Arc<telemetry::TelemetryReport>,
     narinfo_negative_cache: Arc<RwLock<HashSet<String>>>,
+    existing_keys: Arc<RwLock<HashSet<String>>>,
 ) -> Result<()> {
     let mut done = HashSet::new();
 
     while let Some(req) = channel_rx.recv().await {
         match req {
             Request::Shutdown => {
+                tracing::info!("Worker received shutdown signal, draining queue...");
+                // Drain remaining items but don't retry on failure
+                while let Ok(req) = channel_rx.try_recv() {
+                    if let Request::Upload(path) = req {
+                        if done.insert(path.clone()) {
+                            // Best effort upload, no retries since we're shutting down
+                            let _ = upload_path(
+                                api,
+                                store.clone(),
+                                &path,
+                                metrics.clone(),
+                                narinfo_negative_cache.clone(),
+                                existing_keys.clone(),
+                            )
+                            .await;
+                        }
+                    }
+                }
                 break;
             }
             Request::Upload(path) => {
                 if api.circuit_breaker_tripped() {
-                    tracing::trace!("GitHub Actions gave us a 429, so we're done.",);
+                    tracing::trace!("Circuit breaker tripped, skipping upload");
                     continue;
                 }
 
@@ -144,14 +184,23 @@ async fn worker(
                     &path,
                     metrics.clone(),
                     narinfo_negative_cache.clone(),
+                    existing_keys.clone(),
                 )
                 .await
                 {
-                    tracing::error!(
-                        "Upload of path '{}' failed: {}",
-                        store.get_full_path(&path).display(),
-                        err
-                    );
+                    match err {
+                        Error::GhaCache(gha_cache::Error::ShuttingDown) => {
+                            tracing::info!("Upload cancelled due to shutdown");
+                            // Don't log as error, this is expected
+                        }
+                        _ => {
+                            tracing::error!(
+                                "Upload of path '{}' failed: {}",
+                                store.get_full_path(&path).display(),
+                                err
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -166,8 +215,23 @@ async fn upload_path(
     path: &StorePath,
     metrics: Arc<telemetry::TelemetryReport>,
     narinfo_negative_cache: Arc<RwLock<HashSet<String>>>,
+    existing_keys: Arc<RwLock<HashSet<String>>>,
 ) -> Result<()> {
     let path_info = store.query_path_info(path.clone()).await?;
+
+    // Check if this path already exists in the cache
+    let narinfo_key_prefix = format!("{}.narinfo", path.to_hash().as_str());
+    {
+        let keys = existing_keys.read().await;
+        if keys.iter().any(|k| k.starts_with(&narinfo_key_prefix)) {
+            tracing::debug!(
+                "Skipping upload of '{}' - already exists in cache",
+                store.get_full_path(path).display()
+            );
+            metrics.uploads_skipped.incr();
+            return Ok(());
+        }
+    }
 
     // Upload the NAR.
     let nar_path = format!("{}.nar.zstd", path_info.nar_hash.to_base32());
@@ -210,6 +274,10 @@ async fn upload_path(
         .write()
         .await
         .remove(&path.to_hash().to_string());
+
+    // Add to existing_keys to prevent re-upload in same run
+    // Note: We use the full key with suffix that was allocated
+    existing_keys.write().await.insert(narinfo_path.clone());
 
     tracing::info!(
         "Uploaded '{}' to the GitHub Action Cache",

--- a/magic-nix-cache/src/gha.rs
+++ b/magic-nix-cache/src/gha.rs
@@ -148,24 +148,10 @@ async fn worker(
     while let Some(req) = channel_rx.recv().await {
         match req {
             Request::Shutdown => {
-                tracing::info!("Worker received shutdown signal, draining queue...");
-                // Drain remaining items but don't retry on failure
-                while let Ok(req) = channel_rx.try_recv() {
-                    if let Request::Upload(path) = req {
-                        if done.insert(path.clone()) {
-                            // Best effort upload, no retries since we're shutting down
-                            let _ = upload_path(
-                                api,
-                                store.clone(),
-                                &path,
-                                metrics.clone(),
-                                narinfo_negative_cache.clone(),
-                                existing_keys.clone(),
-                            )
-                            .await;
-                        }
-                    }
-                }
+                tracing::info!("Worker received shutdown signal, dropping queued uploads");
+                // API shutdown has already been signaled, so retries are disabled
+                // and uploads would fail immediately. Just discard remaining items.
+                while let Ok(_) = channel_rx.try_recv() {}
                 break;
             }
             Request::Upload(path) => {
@@ -220,10 +206,10 @@ async fn upload_path(
     let path_info = store.query_path_info(path.clone()).await?;
 
     // Check if this path already exists in the cache
-    let narinfo_key_prefix = format!("{}.narinfo", path.to_hash().as_str());
+    let narinfo_path = format!("{}.narinfo", path.to_hash().as_str());
     {
         let keys = existing_keys.read().await;
-        if keys.iter().any(|k| k.starts_with(&narinfo_key_prefix)) {
+        if keys.iter().any(|k| k.starts_with(&narinfo_path)) {
             tracing::debug!(
                 "Skipping upload of '{}' - already exists in cache",
                 store.get_full_path(path).display()
@@ -255,8 +241,6 @@ async fn upload_path(
     );
 
     // Upload the narinfo.
-    let narinfo_path = format!("{}.narinfo", path.to_hash().as_str());
-
     let narinfo_allocation = api.allocate_file_with_random_suffix(&narinfo_path).await?;
 
     let narinfo = path_info_to_nar_info(store.clone(), &path_info, format!("nar/{nar_path}"))
@@ -275,8 +259,8 @@ async fn upload_path(
         .await
         .remove(&path.to_hash().to_string());
 
-    // Add to existing_keys to prevent re-upload in same run
-    // Note: We use the full key with suffix that was allocated
+    // Add base key (without random suffix) to prevent re-upload in same run.
+    // The pre-upload check uses starts_with, so the base key is sufficient.
     existing_keys.write().await.insert(narinfo_path.clone());
 
     tracing::info!(

--- a/magic-nix-cache/src/main.rs
+++ b/magic-nix-cache/src/main.rs
@@ -431,6 +431,7 @@ async fn main_cli(args: Args, recorder: detsys_ids_client::Recorder) -> Result<(
             metrics.clone(),
             narinfo_negative_cache.clone(),
         )
+        .await
         .with_context(|| "Failed to initialize GitHub Actions Cache API")?;
 
         nix_conf

--- a/magic-nix-cache/src/telemetry.rs
+++ b/magic-nix-cache/src/telemetry.rs
@@ -18,6 +18,8 @@ pub struct TelemetryReport {
     pub nars_sent_upstream: Metric,
     pub nars_uploaded: Metric,
 
+    pub uploads_skipped: Metric,
+
     pub num_original_paths: Metric,
     pub num_final_paths: Metric,
     pub num_new_paths: Metric,
@@ -79,6 +81,7 @@ impl TelemetryReport {
             nars_served,
             nars_sent_upstream,
             nars_uploaded,
+            uploads_skipped,
             num_original_paths,
             num_final_paths,
             num_new_paths,
@@ -99,6 +102,7 @@ impl TelemetryReport {
         fact!(recorder, nars_served);
         fact!(recorder, nars_sent_upstream);
         fact!(recorder, nars_uploaded);
+        fact!(recorder, uploads_skipped);
         fact!(recorder, num_original_paths);
         fact!(recorder, num_final_paths);
         fact!(recorder, num_new_paths);


### PR DESCRIPTION
## Summary

This PR addresses the GitHub Actions Cache rate limiting issues reported in #172 by implementing two key improvements:

### 1. List Existing Cache Keys on Startup

**Problem:** The cache was uploading the entire closure on every build, including unchanged NixOS base packages, leading to excessive uploads and rate limiting.

**Solution:**
- On startup, fetch all existing cache entries via GitHub REST API
- Store cache keys in memory (`HashSet<String>`)
- Before uploading any path, check if it already exists and skip if present
- Track skipped uploads with new `uploads_skipped` metric

**Benefits:**
- Single API call on startup vs N individual checks during upload
- Dramatically reduces redundant uploads
- Prevents re-uploading unchanged dependencies

### 2. Implement Proper Retry with Retry-After Support

**Problem:** The circuit breaker tripped permanently on the first 429, and there was no retry logic. Additionally, retries could hang CI if they occurred during shutdown.

**Solution:**
- Parse `Retry-After` header from 429 responses
- Implement exponential backoff retry (1s, 2s, 4s, 8s, 16s, max 60s)
- Retry up to 5 times before tripping circuit breaker
- **Critically:** Stop retrying immediately when BOTH conditions are met:
  1. Shutdown has been signaled (via `/api/workflow-finish`)
  2. AND we receive a 429 rate limit error

**Benefits:**
- Respects GitHub's rate limits properly
- Resilient to temporary rate limiting during normal operation
- Never hangs CI waiting for retry when workflow is finishing
- Only trips circuit breaker after exhausting all retries

## Implementation Details

### Files Modified

- **`gha-cache/src/credentials.rs`**: Added `github_token` and `github_repository` fields for REST API access
- **`gha-cache/src/api.rs`**: 
  - Added `list_existing_cache_keys()` method with pagination
  - Added `shutting_down` flag and `signal_shutdown()` method
  - Implemented `execute_with_retry()` wrapper with exponential backoff
  - Updated error handling to parse `Retry-After` header
  - Wrapped critical operations (reserve, commit, finalize, get) with retry logic
- **`magic-nix-cache/src/gha.rs`**:
  - Added `existing_keys` HashSet to `GhaCache` struct
  - Fetch existing keys on startup (best effort, doesn't fail if unavailable)
  - Check before upload and skip if key exists
  - Call `api.signal_shutdown()` in `shutdown()` method
  - Updated worker to handle `ShuttingDown` error gracefully
- **`magic-nix-cache/src/telemetry.rs`**: Added `uploads_skipped` metric
- **`magic-nix-cache/src/main.rs`**: Updated to call async `GhaCache::new()`

### Shutdown Behavior

The retry logic ensures we balance resilience with responsiveness:

**Normal Operation:**
- Retry on 429 with exponential backoff
- Keep trying up to 5 attempts
- Only give up after MAX_RETRIES

**During Shutdown:**
- If operation succeeds: Complete normally
- If 429 received: Immediately return `ShuttingDown` error (no retry)
- If waiting for retry: Abort wait and return `ShuttingDown` error

This prevents the CI from hanging indefinitely when `/api/workflow-finish` is called while rate limited.

## Usage

The GitHub Action needs to pass `GITHUB_TOKEN` for cache listing to work:

```yaml
- uses: DeterminateSystems/magic-nix-cache-action@main
  env:
    GITHUB_TOKEN: ${{ github.token }}
```

The `GITHUB_REPOSITORY` variable is already set by GitHub Actions automatically.

## Testing

The code changes are syntactically correct. Full compilation requires system dependencies (`nix-main`, `protoc`) that are available in the Nix build environment.

## Expected Impact

**Before:**
- Uploads entire closure every time (including unchanged base packages)
- Hits 200/minute rate limit easily
- Circuit breaker trips permanently on first 429
- CI can hang if 429 happens during shutdown

**After:**
- Skips uploads for paths that already exist
- Retries with proper backoff on 429
- Only trips circuit breaker after 5 failed retries
- Shuts down immediately when requested, even during retry wait

Fixes #172
Related to #147, #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retries with exponential backoff for API rate limits and graceful abort on shutdown.
  * Preloads and tracks existing cache keys to skip redundant uploads.
  * Shutdown now drains queued uploads and treats shutdown-cancelled operations as expected.
  * New telemetry metric reporting skipped uploads.
  * Optional environment-configurable GitHub token/repository support for cache operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->